### PR TITLE
Removes unused outputs key to fix build error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,6 @@ inputs:
     required: false
     default: ''
 
-outputs:
 branding:
   icon: 'check-square'  
   color: 'green'  


### PR DESCRIPTION
Release https://github.com/microsoft/ApplicationInspector-Action/releases/tag/v1 fails with the following error:

```
System.ArgumentException: Unexpected type 'NullToken' encountered while reading 'outputs'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
```

The issue is with the `outputs:` key. It doesn't seem to be used and removing it resolved the issue for me. 