### PR TITLE
Update Dockerfile to use sdk:8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 RUN mkdir /tools
 


### PR DESCRIPTION
```
...

#5 extracting sha256:b25595df572c41dfde1ff0ebe1926f380e21870c9525ef929991ca3f3b870352 2.9s done
#5 extracting sha256:17701958766f7af9dd1c203824a21d9ba620df4f6845bafb53eb19b6543204fa
#5 extracting sha256:17701958766f7af9dd1c203824a21d9ba620df4f6845bafb53eb19b6543204fa 0.3s done
#5 DONE 9.4s

#6 [2/6] RUN mkdir /tools
#6 DONE 0.2s

#7 [3/6] RUN dotnet tool install --tool-path /tools Microsoft.CST.ApplicationInspector.Cli
#7 5.550 /tmp/f50ce845-e5eb-48b3-87d0-bc054a4b48dd/restore.csproj : error NU1202: Package Microsoft.CST.ApplicationInspector.CLI 1.9.44 is not compatible with net6.0 (.NETCoreApp,Version=v6.0) / any. Package Microsoft.CST.ApplicationInspector.CLI 1.9.44 supports:
#7 5.550 /tmp/f50ce845-e5eb-48b3-87d0-bc054a4b48dd/restore.csproj : error NU1202:   - net8.0 (.NETCoreApp,Version=v8.0) / any
#7 5.550 /tmp/f50ce845-e5eb-48b3-87d0-bc054a4b48dd/restore.csproj : error NU1202:   - net9.0 (.NETCoreApp,Version=v9.0) / any
#7 5.645 The tool package could not be restored.
#7 5.645 Tool 'microsoft.cst.applicationinspector.cli' failed to install. This failure may have been caused by:
#7 5.645 
#7 5.645 * You are attempting to install a preview release and did not use the --version option to specify the version.
#7 5.645 * A package by this name was found, but it was not a .NET tool.
#7 5.645 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
#7 5.645 * You mistyped the name of the tool.
#7 5.645 
#7 5.645 For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool
#7 ERROR: process "/bin/sh -c dotnet tool install --tool-path /tools Microsoft.CST.ApplicationInspector.Cli" did not complete successfully: exit code: 1
```